### PR TITLE
saturation --bcstat takes a comma-separated list

### DIFF
--- a/script/stereoRun_multiLane_v4.1.0.sh
+++ b/script/stereoRun_multiLane_v4.1.0.sh
@@ -290,7 +290,7 @@ singularity exec ${visualSif} saturation \
     -i ${saturationFile} \
     --tissue ${result_04tissuecut}/${SNid}.tissue.gef \
     -o ${result_06saturation} \
-    --bcstat ${bcStat} \
+    --bcstat ${bcStatStr} \
     --summary ${result_02count}/${SNid}.Aligned.sortedByCoord.out.merge.q10.dedup.target.bam.summary.stat &&\
 ## organize your outputs (optional)
 if [[ ! -f $result_sn/${SNid}.saturation.bin200.png ]]


### PR DESCRIPTION
I noticed the non-comma separated version of the variable is passed to the saturation program.

Inspecting the source code of the saturation program [here](https://github.com/BGIResearch/SAW_Saturation/blob/477d44baba31fdb0fd4fa93838bd82645c8c0c1e/src/saturation.cpp#L111-L113) and [here](https://github.com/BGIResearch/SAW_Saturation/blob/477d44baba31fdb0fd4fa93838bd82645c8c0c1e/src/saturation.cpp#L142) show that it indeed requires this argument to be comma separated.